### PR TITLE
Add quick access to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ This project provides a PowerPoint automation server that works with Claude Desk
 - Set slide titles
 - And more!
 
+## Quick Start
+1. Use `uvx` to run:
+```bash
+uvx --from https://github.com/socamalo/PPT_MCP_Server.git mcp-ppt
+```
+
 ## Installation
 
 1. Clone this repository:

--- a/main.py
+++ b/main.py
@@ -403,7 +403,9 @@ def close_presentation(presentation_id: str, save: bool = True) -> Dict[str, Any
     pres = ppt_automation.presentations[presentation_id]
     
     try:
-        pres.Close(save)
+        if save:
+            pres.Save()
+        pres.Close()
         del ppt_automation.presentations[presentation_id]
         return {"success": True}
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -846,5 +846,9 @@ def get_shape_type_name(type_id):
     }
     return shape_types.get(type_id, f"Unknown Type ({type_id})")
 
-if __name__ == "__main__":
+
+def main():
     mcp.run(transport="stdio")
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ dependencies = [
     "pywin32>=310",
     "requests>=2.32.3",
 ]
+
+[project.scripts]
+mcp-ppt = "main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,4 @@ dependencies = [
 
 [project.scripts]
 mcp-ppt = "main:main"
+ppt-mcp = "main:main"


### PR DESCRIPTION
Add quick start cli named "mcp-ppt", "ppt-mcp".

Add a quick use CLI named 'mcp ppt' and 'ppt mcp', which supports direct running of 'uvx'. 
Running example:
 `uvx --from https://github.com/socamalo/PPT_MCP_Server.git  mcp-ppt`